### PR TITLE
Update the task to build web app distribution

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build
         run: |
-          ./gradlew wasmJsBrowserProductionWebpack --no-configuration-cache
+          ./gradlew wasmJsBrowserDistribution --no-configuration-cache
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.5


### PR DESCRIPTION
'wasmJsBrowserDistribution' should be used with koltin 2.0.0-RC1 and newer